### PR TITLE
issue #40 cloud animation fix

### DIFF
--- a/src/app/(landing)/page.tsx
+++ b/src/app/(landing)/page.tsx
@@ -5,6 +5,7 @@ import { useRouter } from "next/navigation";
 import Cartridge from "./Cartridge";
 import Console from "./Console";
 import LoadingPage from "./loading";
+import { Clouds } from "@/app/leaderboard/_components";
 
 export default function Landing() {
   const [inserted, setInserted] = useState(false);
@@ -84,6 +85,11 @@ export default function Landing() {
           backgroundSize: "20px 20px",
         }}
       />
+
+      {/* Floating clouds with even distribution and delta-time animation */}
+      <div className="absolute inset-0 z-5 pointer-events-none">
+        <Clouds />
+      </div>
 
       {/* Centered container with fixed aspect ratio */}
       <div className="relative w-full max-w-[400px] aspect-[3/2] z-10">

--- a/src/app/leaderboard/_components/Clouds.tsx
+++ b/src/app/leaderboard/_components/Clouds.tsx
@@ -1,33 +1,38 @@
 import React, { useMemo } from 'react';
 import { CloudImageProps } from './types';
-import { STATIC_CLOUDS } from './constants';
+import { STATIC_CLOUDS, SCREEN } from './constants';
 import { CloudComponent } from './Cloud';
 import { useViewportSize } from '@/hooks/useViewportSize';
 
 export function Clouds() {
   const viewportSize = useViewportSize();
 
-  // Memoized clouds with responsive positioning
   const clouds = useMemo(() => {
     if (viewportSize.width === 0) return STATIC_CLOUDS.map((cloud, index) => ({ ...cloud, baseLeft: 120 }));
-    
-    const baseLeftPositions = [
-      120, // Fixed position for first cloud
-      55,  // Fixed position for second cloud
-      Math.max(1150, viewportSize.width - 390),
-      333, // Fixed position for fourth cloud
-      Math.max(1200, viewportSize.width - 280),
-      Math.max(1250, viewportSize.width - 374),
-    ];
+    const count = STATIC_CLOUDS.length;
+    const screenCenterX = SCREEN.left + SCREEN.width / 2;
+    const spread = Math.max(SCREEN.width * 0.65, viewportSize.width * 0.5);
 
-    return STATIC_CLOUDS.map((cloud, index) => ({
-      ...cloud,
-      baseLeft: baseLeftPositions[index],
-      baseTop: index === 3 ? Math.min(760, viewportSize.height - 125) :
-               index === 4 ? Math.min(640, viewportSize.height - 200) :
-               index === 5 ? Math.max(-13, -50) :
-               cloud.baseTop,
-    }));
+    return STATIC_CLOUDS.map((cloud, index) => {
+      const t = count > 1 ? index / (count - 1) : 0.5;
+      let anchorNormalized = t * 2 - 1;
+
+      const jitter = Math.sin(index * 2.17) * 0.06;
+      anchorNormalized += jitter;
+
+      const desiredCenter = screenCenterX + anchorNormalized * spread;
+      const left = Math.round(desiredCenter - (cloud.width || 0) / 2);
+      const clampedLeft = Math.max(-Math.floor((cloud.width || 0) * 0.3), Math.min(viewportSize.width - Math.ceil((cloud.width || 0) * 0.7), left));
+
+      return {
+        ...cloud,
+        baseLeft: clampedLeft,
+        baseTop: index === 3 ? Math.min(760, viewportSize.height - 125) :
+                 index === 4 ? Math.min(640, viewportSize.height - 200) :
+                 index === 5 ? Math.max(-13, -50) :
+                 cloud.baseTop,
+      };
+    });
   }, [viewportSize.width, viewportSize.height]);
 
   return (

--- a/src/app/leaderboard/_components/constants.ts
+++ b/src/app/leaderboard/_components/constants.ts
@@ -70,6 +70,12 @@ export const STATIC_CLOUDS: Omit<CloudImageProps, 'baseLeft'>[] = [
   { src: '/images/cloud3.png', width: 240, height: 125, baseTop: 760, amplitude: 18, speed: 1.2, phase: 3 },
   { src: '/images/cloud3.png', width: 240, height: 125, baseTop: 640, amplitude: 16, speed: 1.0, phase: 4 },
   { src: '/images/cloud1.png', width: 324, height: 170, baseTop: -13, amplitude: 20, speed: 0.97, phase: 5 },
+  { src: '/images/cloud2.png', width: 300, height: 160, baseTop: 40, amplitude: 12, speed: 0.9, phase: 6 },
+  { src: '/images/cloud1.png', width: 280, height: 150, baseTop: 220, amplitude: 18, speed: 1.05, phase: 7 },
+  { src: '/images/cloud3.png', width: 200, height: 110, baseTop: 320, amplitude: 10, speed: 1.3, phase: 8 },
+  { src: '/images/cloud1.png', width: 340, height: 170, baseTop: 520, amplitude: 24, speed: 0.88, phase: 9 },
+  { src: '/images/cloud2.png', width: 260, height: 140, baseTop: 420, amplitude: 15, speed: 1.15, phase: 10 },
+  { src: '/images/cloud3.png', width: 220, height: 120, baseTop: 80, amplitude: 13, speed: 1.0, phase: 11 },
 ];
 
 export function getThemeColors(isDarkMode: boolean) {


### PR DESCRIPTION
useCloudFloat hook uses delta-time animation instead of frame-based
Use requestAnimationFrame timestamps with phase accumulator 
Increase STATIC_CLOUDS from 6 to 12 and fixed positions to better match figma design
Position clouds relative to screen center using equal width bins for even visual spacing
